### PR TITLE
Moving Discord Bot Token and Guild ID to server side and redoing some basic stuff.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -24,8 +24,6 @@
 ]]
 
 Config = {
-    DiscordGuildID = '',
-    DiscordBotToken = '',
     Reward = {
         type = 'cash',
         amount = 1500,

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -6,7 +6,7 @@ function ObtainDiscordIdentifier(src)
 end
 
 function Notify(src, text, notifType)
-    QBCore.Functions.Notify(src, text, notifType)
+    TriggerClientEvent('QBCore:Notify', src, text, notifType)
 end
 
 function ProduceReward(src)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,6 @@
+local DiscordGuildID = '',
+local DiscordBotToken = '',
+
 -- Functions
 function CollectedThisMonth(discord)
     local row = MySQL.query.await('SELECT * FROM b_discordbooster WHERE discord=?', { discord })
@@ -16,8 +19,7 @@ end
 RegisterCommand('checkboost', function(source)
     local src = source
     local discord = ObtainDiscordIdentifier(src)
-    local url = string.format('https://discord.com/api/v9/guilds/%s/members/%s', Config.DiscordGuildID, tostring(discord))
-    print(discord)
+    local url = string.format('https://discord.com/api/v9/guilds/%s/members/%s', DiscordGuildID, tostring(discord))
 
     PerformHttpRequest(url, function (errorCode, rdata, resultHeaders)
         local res = json.decode(rdata)
@@ -35,7 +37,7 @@ RegisterCommand('checkboost', function(source)
                 end
             end
         else
-            print(errorCode)
+            print('^3[ ERROR ] ^7| ^1Code 200 was not reached. ^7| Recieved: ( ^8'..errorCode..' ^7)')
         end
-    end, "GET", "", {["Content-type"] = "application/json", ["Authorization"] = string.format('Bot %s', Config.DiscordBotToken)})
+    end, "GET", "", {["Content-type"] = "application/json", ["Authorization"] = string.format('Bot %s', DiscordBotToken)})
 end, false)


### PR DESCRIPTION
This pull request ensures that client modders/dumpers won't have access to the bot token because it has been moved from the config to the server side
Edit : Changed the notification function to event,